### PR TITLE
Revert "chore(nodejs): update client ref docs link in metadata (#360)"

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,6 +4,5 @@
   "release_level": "ga",
   "language": "nodejs",
   "repo": "googleapis/google-p12-pem",
-  "distribution_name": "google-p12-pem",
-  "client_documentation": "https://cloud.google.com/nodejs/docs/reference/google-p12-pem/latest"
+  "distribution_name": "google-p12-pem"
 }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Convert Google .p12 keys to .pem keys.
 A comprehensive list of changes in each version may be found in
 [the CHANGELOG](https://github.com/googleapis/google-p12-pem/blob/main/CHANGELOG.md).
 
-* [google-p12-pem Node.js Client API Reference][client-docs]
+
 
 * [github.com/googleapis/google-p12-pem](https://github.com/googleapis/google-p12-pem)
 
@@ -85,9 +85,6 @@ Samples are in the [`samples/`](https://github.com/googleapis/google-p12-pem/tre
 
 
 
-The [google-p12-pem Node.js Client API Reference][client-docs] documentation
-also contains samples.
-
 ## Supported Node.js Versions
 
 Our client libraries follow the [Node.js release schedule](https://nodejs.org/en/about/releases/).
@@ -144,7 +141,7 @@ Apache Version 2.0
 
 See [LICENSE](https://github.com/googleapis/google-p12-pem/blob/main/LICENSE)
 
-[client-docs]: https://cloud.google.com/nodejs/docs/reference/google-p12-pem/latest
+
 
 [shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
 [projects]: https://console.cloud.google.com/project


### PR DESCRIPTION
This reverts commit 12484774e20a3ef32d9351382a0d62458063ca6b.

p12-pem didn't have docs on googleapis.dev and shouldn't have ref docs
on cloud.google.com either.

Internally see b/195673031
