### PR TITLE
use first or second element of the array whichever has the .key

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,7 +53,10 @@ function convertToPem(p12base64: string): string {
   const p12 = forge.pkcs12.pkcs12FromAsn1(p12Asn1, 'notasecret');
   const bags = p12.getBags({friendlyName: 'privatekey'});
   if (bags.friendlyName) {
-    const privateKey = bags.friendlyName[0].key!;
+    // Return the key from either of the elements if it exists.
+    const privateKey =
+      (bags.friendlyName[0] && bags.friendlyName[0].key!) ||
+      (bags.friendlyName[1] && bags.friendlyName[1].key!);
     const pem = forge.pki.privateKeyToPem(privateKey);
     return pem.replace(/\r\n/g, '\n');
   } else {


### PR DESCRIPTION
I have created an issue #451 and am proposing this change.

I don't understand the reason why the first element was used earlier, and I don't understand why I should be using the 2nd one. So, I have modified it so that it can use either of the element that has the key attribute. My code was failing and I had to make this change urgently. I would like to understand why this happened.